### PR TITLE
Add payrexx fee attribute

### DIFF
--- a/lib/Payrexx/Models/Response/Transaction.php
+++ b/lib/Payrexx/Models/Response/Transaction.php
@@ -27,6 +27,7 @@ class Transaction extends \Payrexx\Models\Request\Transaction
     private $invoice;
     private $contact;
     private $pageUuid;
+    private $payrexx_fee;
 
     const CONFIRMED = 'confirmed';
     const INITIATED = 'initiated';
@@ -230,5 +231,21 @@ class Transaction extends \Payrexx\Models\Request\Transaction
     public function setPageUuid($pageUuid): void
     {
         $this->pageUuid = $pageUuid;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPayrexx_fee()
+    {
+        return $this->payrexx_fee;
+    }
+
+    /**
+     * @param int $payrexxFee
+     */
+    public function setPayrexx_fee($payrexxFee): void
+    {
+        $this->payrexx_fee = $payrexxFee;
     }
 }


### PR DESCRIPTION
Added missing `payrexx_fee`-Attribute to the Transaction-Response class.

---

## 👨‍🏫 Explanation

### 1) The webhook data returns `payrexx_fee`:

```json
{
    "transaction": {
        "payrexx_fee": 123
    }
}
```

### 2) You convert the webhook-data to an `Transaction`-object

```php
use use Payrexx\Models\Response\Transaction;

$transaction = (new Transaction())->fromArray([
    'payrexx_fee' => 123,
]);
```

### 3) Try to access `payrexx_fee`

```
$transaction->getPayrexx_fee(); // ❌ Not possible
```
