### PR TITLE
Add basic ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+vendor
+composer.lock


### PR DESCRIPTION
Hi

I wanted to fix a bug and saw that this package is a little outdated regarding best practices.

This PR adds the `vendor` dir and `composer.lock` to the `.gitignore`. These two should never be pushed.