### PR TITLE
Bug: $uuid must be protected

### DIFF
--- a/lib/Payrexx/Models/Request/Design.php
+++ b/lib/Payrexx/Models/Request/Design.php
@@ -114,7 +114,7 @@ class Design extends Base
     /**
      * @param string $uuid
      */
-    public function setUuid(string $uuid): void
+    public function setUuid($uuid): void
     {
         $this->uuid = $uuid;
     }

--- a/lib/Payrexx/Models/Request/QrCode.php
+++ b/lib/Payrexx/Models/Request/QrCode.php
@@ -63,7 +63,7 @@ class QrCode extends \Payrexx\Models\Base
     /**
      * @param string $uuid
      */
-    public function setUuid(string $uuid): void
+    public function setUuid($uuid): void
     {
         $this->uuid = $uuid;
     }

--- a/lib/Payrexx/Models/Response/Transaction.php
+++ b/lib/Payrexx/Models/Response/Transaction.php
@@ -16,7 +16,6 @@ namespace Payrexx\Models\Response;
 class Transaction extends \Payrexx\Models\Request\Transaction
 {
 
-    private $uuid;
     private $time;
     private $status;
     private $lang;


### PR DESCRIPTION
Hi

In the latest version [v1.8.4](https://github.com/payrexx/payrexx-php/releases/tag/v1.8.4) a type conflict error was added in https://github.com/payrexx/payrexx-php/commit/edb6dc6b8169a6a747050bccab5dfba936375782#diff-10b0dfe21db2bdcd3d977fd04c0b09bd6c3cdfd98d8424f3a101c71dd5012ed1.

This PR removes the property `uuid` from the `Response\Transaction.php` to prevent a modifier conflict with the new parent class `Models\Base.php` property.