### PR TITLE
Add PHPStan to prevent type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: php-actions/composer@v6 
+    - uses: php-actions/phpstan@v3
+      with:
+        path: lib/
+

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,12 @@
         }
     },
     "require": {
-        "php": ">=5.4"
+        "php": "^8.0"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^1.9"
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse lib/"
     }
 }


### PR DESCRIPTION
Hi

This PR adds a GitHub action that runs PHPStan ([Docs](https://phpstan.org/user-guide/getting-started) / [GitHub Action](https://github.com/marketplace/actions/phpstan-php-actions)) and checks the types and other circumstances and warns about errors.

This PR should be merged after the https://github.com/payrexx/payrexx-php/pull/36, because otherwise it still shows the existing errors.