### PR TITLE
Add the possibility to add custom field name as string

### DIFF
--- a/examples/GatewayCreate.php
+++ b/examples/GatewayCreate.php
@@ -119,6 +119,7 @@ $gateway->addField($type = 'custom_field_1', $value = '123456789', $name = array
     3 => 'Benutzerdefiniertes Feld (FR)',
     4 => 'Benutzerdefiniertes Feld (IT)',
 ));
+$gateway->addField($type = 'custom_field_2', $value = '123456789', $name = 'Custom Field');
 
 try {
     $response = $payrexx->create($gateway);

--- a/lib/Payrexx/Models/Request/Gateway.php
+++ b/lib/Payrexx/Models/Request/Gateway.php
@@ -486,7 +486,7 @@ class Gateway extends \Payrexx\Models\Base
      * @param   string  $value          Value of field
      *                                  For field of type "title" use value "mister" or "miss"
      *                                  For field of type "country" pass the 2 letter ISO code
-     * @param   array   $name           Name of the field (only available for fields of type "custom_field_1-5"
+     * @param   array|string   $name    Name of the field (only available for fields of type "custom_field_1-5"
      */
     public function addField($type, $value, $name = array())
     {


### PR DESCRIPTION
I'm doing this PR because i've noticed that when i want to add a custom field, if there is only entry in the `$name` (expecting array) parameter, the custom_field won't have his name reported in Payrexx or the webhooks : 

## Problem : 

Does not work : 
```php
$gateway->addField($type = 'custom_field_2', $value = '123456789', $name = [
	'Identifier'
]);
```
![image](https://github.com/payrexx/payrexx-php/assets/8202241/db0acc8c-b815-4bf2-a552-dd15db9734e9)
![image](https://github.com/payrexx/payrexx-php/assets/8202241/355e58ee-be36-4669-ad98-4f911ca7a945)

I guess it expect to have an array with an index with country codes, but in my case i don't care if the custom field is translated, and i don't want to have to translate it in any language :) 

## Solution :

But when i do this, it does work : 
```php
$gateway->addField($type = 'custom_field_2', $value = '123456789', $name = 'Identifier');
```

![image](https://github.com/payrexx/payrexx-php/assets/8202241/e0559536-0747-4191-a8fa-d29ada2ce11e)
![image](https://github.com/payrexx/payrexx-php/assets/8202241/701c5001-33d2-4260-98cf-2eadd6456ff5)

But when i do this, my PHPStan doesn't like this at all : 
![image](https://github.com/payrexx/payrexx-php/assets/8202241/95f0c97a-8717-4a10-b823-b327507c1a19)

This PR so resolve it 🙏 

As you see, it's not a big deal ;)


