### PR TITLE
Provide method to retrieve a payout with details

### DIFF
--- a/examples/PayoutDetails.php
+++ b/examples/PayoutDetails.php
@@ -1,0 +1,33 @@
+<?php
+
+use Payrexx\Models\Request\Payout;
+use Payrexx\Payrexx;
+use Payrexx\PayrexxException;
+
+spl_autoload_register(function($class) {
+    $root = dirname(__DIR__);
+    $classFile = $root . '/lib/' . str_replace('\\', '/', $class) . '.php';
+    if (file_exists($classFile)) {
+        require_once $classFile;
+    }
+});
+
+// $instanceName is a part of the url where you access your payrexx installation.
+// https://{$instanceName}.payrexx.com
+$instanceName = 'YOUR_INSTANCE_NAME';
+
+// $secret is the payrexx secret for the communication between the applications
+// if you think someone got your secret, just regenerate it in the payrexx administration
+$secret = 'YOUR_SECRET';
+
+$payrexx = new Payrexx($instanceName, $secret);
+
+$payout = new Payout();
+$payout->setUuid('YOUR_UUID');
+
+try {
+    $response = $payrexx->details($payout);
+    var_dump($response);
+} catch (PayrexxException $e) {
+    print $e->getMessage();
+}

--- a/lib/Payrexx/Communicator.php
+++ b/lib/Payrexx/Communicator.php
@@ -35,7 +35,7 @@ class Communicator
         'update'       => 'PUT',
         'getAll'       => 'GET',
         'getOne'       => 'GET',
-        'details'       => 'GET',
+        'details'      => 'GET',
     );
     /**
      * @var string The Payrexx instance name.

--- a/lib/Payrexx/Communicator.php
+++ b/lib/Payrexx/Communicator.php
@@ -35,6 +35,7 @@ class Communicator
         'update'       => 'PUT',
         'getAll'       => 'GET',
         'getOne'       => 'GET',
+        'details'       => 'GET',
     );
     /**
      * @var string The Payrexx instance name.
@@ -124,7 +125,7 @@ class Communicator
             $id = $params['uuid'];
         }
 
-        $act = in_array($method, ['refund', 'capture', 'receipt', 'preAuthorize']) ? $method : '';
+        $act = in_array($method, ['refund', 'capture', 'receipt', 'preAuthorize', 'details']) ? $method : '';
         $apiUrl = sprintf(self::API_URL_FORMAT, $this->apiBaseDomain, 'v' . $this->version, $params['model'], $id, $act);
 
         $httpMethod = $this->getHttpMethod($method) === 'PUT' && $params['model'] === 'Design'


### PR DESCRIPTION
Add the method corresponding to the endpoint "Retrieve a Payout With Details" because transfers are not available with the getOne and getAll methods.

Example:
```php
$payrexx = new Payrexx('YOUR_INSTANCE_NAME', 'YOUR_SECRET');

$payout = new Payout();
$payout->setUuid('YOUR_UUID');

$payoutWithDetails = $payrexx->details($payout);
```