### PR TITLE
remove deprecated curl_close

### DIFF
--- a/lib/Payrexx/CommunicationAdapter/CurlCommunication.php
+++ b/lib/Payrexx/CommunicationAdapter/CurlCommunication.php
@@ -120,7 +120,6 @@ class CurlCommunication extends AbstractCommunication
                 'message' => $this->curlError($curl)
             ];
         }
-        curl_close($curl);
 
         if (($responseInfo['content_type'] ?? '') === 'application/json') {
             $responseBody = json_decode($responseBody, true);


### PR DESCRIPTION
`curl_close()` has been deprecated in PHP 8.5.

These functions had no effect since PHP 8.0. 
Calling them now emits a deprecation notice in PHP 8.5

see https://www.php.net/manual/en/function.curl-close.php
