### PR TITLE
bugfix/PP-20189: FPM worker segfault from circular getResponseModel() return types

### DIFF
--- a/lib/Payrexx/Models/Request/AuthToken.php
+++ b/lib/Payrexx/Models/Request/AuthToken.php
@@ -38,7 +38,10 @@ class AuthToken extends Base
         $this->userId = $userId;
     }
 
-    public function getResponseModel(): ResponseAuthToken
+    /**
+     * @return ResponseAuthToken
+     */
+    public function getResponseModel(): object
     {
         return new ResponseAuthToken();
     }

--- a/lib/Payrexx/Models/Request/Bill.php
+++ b/lib/Payrexx/Models/Request/Bill.php
@@ -316,7 +316,10 @@ class Bill extends Base
         $this->limit = $limit;
     }
 
-    public function getResponseModel(): ResponseBill
+    /**
+     * @return ResponseBill
+     */
+    public function getResponseModel(): object
     {
         return new ResponseBill();
     }

--- a/lib/Payrexx/Models/Request/Design.php
+++ b/lib/Payrexx/Models/Request/Design.php
@@ -401,7 +401,10 @@ class Design extends Base
         $this->limit = $limit;
     }
 
-    public function getResponseModel(): ResponseDesign
+    /**
+     * @return ResponseDesign
+     */
+    public function getResponseModel(): object
     {
         return new ResponseDesign();
     }

--- a/lib/Payrexx/Models/Request/Gateway.php
+++ b/lib/Payrexx/Models/Request/Gateway.php
@@ -902,8 +902,10 @@ class Gateway extends Base
 
     /**
      * {@inheritdoc}
+     *
+     * @return ResponseGateway
      */
-    public function getResponseModel(): ResponseGateway
+    public function getResponseModel(): object
     {
         return new ResponseGateway();
     }

--- a/lib/Payrexx/Models/Request/Invoice.php
+++ b/lib/Payrexx/Models/Request/Invoice.php
@@ -386,7 +386,10 @@ class Invoice extends Base
         $this->expirationDate = $expirationDate;
     }
 
-    public function getResponseModel(): ResponseInvoice
+    /**
+     * @return ResponseInvoice
+     */
+    public function getResponseModel(): object
     {
         return new ResponseInvoice();
     }

--- a/lib/Payrexx/Models/Request/Page.php
+++ b/lib/Payrexx/Models/Request/Page.php
@@ -271,7 +271,10 @@ class Page extends Base
         ];
     }
 
-    public function getResponseModel(): ResponsePage
+    /**
+     * @return ResponsePage
+     */
+    public function getResponseModel(): object
     {
         return new ResponsePage();
     }

--- a/lib/Payrexx/Models/Request/PaymentMethod.php
+++ b/lib/Payrexx/Models/Request/PaymentMethod.php
@@ -56,7 +56,10 @@ class PaymentMethod extends Base
         $this->filterPsp = $filterPsp;
     }
 
-    public function getResponseModel(): ResponsePaymentMethod
+    /**
+     * @return ResponsePaymentMethod
+     */
+    public function getResponseModel(): object
     {
         return new ResponsePaymentMethod();
     }

--- a/lib/Payrexx/Models/Request/PaymentProvider.php
+++ b/lib/Payrexx/Models/Request/PaymentProvider.php
@@ -54,7 +54,10 @@ class PaymentProvider extends Base
         $this->activePaymentMethods = $activePaymentMethods;
     }
 
-    public function getResponseModel(): ResponsePaymentProvider
+    /**
+     * @return ResponsePaymentProvider
+     */
+    public function getResponseModel(): object
     {
         return new ResponsePaymentProvider();
     }

--- a/lib/Payrexx/Models/Request/Payout.php
+++ b/lib/Payrexx/Models/Request/Payout.php
@@ -68,7 +68,10 @@ class Payout extends Base
         $this->statementDescriptor = $statementDescriptor;
     }
 
-    public function getResponseModel(): ResponsePayout
+    /**
+     * @return ResponsePayout
+     */
+    public function getResponseModel(): object
     {
         return new ResponsePayout();
     }

--- a/lib/Payrexx/Models/Request/QrCode.php
+++ b/lib/Payrexx/Models/Request/QrCode.php
@@ -33,7 +33,10 @@ class QrCode extends Base
         $this->webshopUrl = $webshopUrl;
     }
 
-    public function getResponseModel(): ResponseQrCode
+    /**
+     * @return ResponseQrCode
+     */
+    public function getResponseModel(): object
     {
         return new ResponseQrCode();
     }

--- a/lib/Payrexx/Models/Request/QrCodeScan.php
+++ b/lib/Payrexx/Models/Request/QrCodeScan.php
@@ -33,7 +33,10 @@ class QrCodeScan extends Base
         $this->sessionId = $sessionId;
     }
 
-    public function getResponseModel(): ResponseQrCodeScan
+    /**
+     * @return ResponseQrCodeScan
+     */
+    public function getResponseModel(): object
     {
         return new ResponseQrCodeScan();
     }

--- a/lib/Payrexx/Models/Request/SignatureCheck.php
+++ b/lib/Payrexx/Models/Request/SignatureCheck.php
@@ -20,7 +20,10 @@ use Payrexx\Models\Response\SignatureCheck as ResponseSignatureCheck;
  */
 class SignatureCheck extends Base
 {
-    public function getResponseModel(): ResponseSignatureCheck
+    /**
+     * @return ResponseSignatureCheck
+     */
+    public function getResponseModel(): object
     {
         return new ResponseSignatureCheck();
     }

--- a/lib/Payrexx/Models/Request/Subscription.php
+++ b/lib/Payrexx/Models/Request/Subscription.php
@@ -163,7 +163,10 @@ class Subscription extends Base
         $this->limit = $limit;
     }
 
-    public function getResponseModel(): ResponseSubscription
+    /**
+     * @return ResponseSubscription
+     */
+    public function getResponseModel(): object
     {
         return new ResponseSubscription();
     }

--- a/lib/Payrexx/Models/Request/Transaction.php
+++ b/lib/Payrexx/Models/Request/Transaction.php
@@ -246,8 +246,10 @@ class Transaction extends Base
 
     /**
      * {@inheritdoc}
+     *
+     * @return ResponseTransaction
      */
-    public function getResponseModel(): ResponseTransaction
+    public function getResponseModel(): object
     {
         return new ResponseTransaction();
     }

--- a/lib/Payrexx/Payrexx.php
+++ b/lib/Payrexx/Payrexx.php
@@ -19,7 +19,7 @@ use Payrexx\Models\Base;
  */
 class Payrexx
 {
-    public const CLIENT_VERSION = '2.0.14';
+    public const CLIENT_VERSION = '2.0.15';
 
     protected Communicator $communicator;
 


### PR DESCRIPTION
**Problem:**
The 16 Request models narrowed getResponseModel() covariantly to their
concrete response class (e.g. `: ResponseGateway`), while Response\X extends
Request\X. To verify that covariant return type, PHP must resolve Response\X
while still linking Request\X — loading a class that inherits from the one
currently being linked. Combined with the OPcache inheritance cache this
half-linked state segfaulted PHP-FPM workers, so webhooks failed with HTTP
502 (nginx) / 503 (Apache) and no PHP error-log entry.

The typed return was introduced with the 2.0.x line; in 1.x getResponseModel() had no return type, so no covariant resolution was forced and the crash did not occur.

**Fix:**
Set the return type back to object (matching the abstract parent
Base::getResponseModel(): object) and keep the concrete type in an
return docblock for IDE/static analysis. Behaviour is unchanged; the
circular inheritance is no longer resolved at link time.

**Verified**:
Deterministic single-worker harness went 5/5 segfaults to 0/5;
real checkout/cancel/webhook path clean;