### PR TITLE
bugfix/PP-20387: Add cURL connect/timeout to prevent hung API calls

### DIFF
--- a/lib/Payrexx/CommunicationAdapter/CurlCommunication.php
+++ b/lib/Payrexx/CommunicationAdapter/CurlCommunication.php
@@ -46,6 +46,10 @@ class CurlCommunication extends AbstractCommunication
             CURLOPT_USERAGENT => 'payrexx-php/' . Payrexx::CLIENT_VERSION,
             CURLOPT_SSL_VERIFYPEER => true,
             CURLOPT_CAINFO => dirname(__DIR__) . '/certs/ca.pem',
+            // Bound the request so a slow API fails as a normal cURL error instead of
+            // hanging until PHP's max_execution_time kills the process mid-request.
+            CURLOPT_CONNECTTIMEOUT => 5,
+            CURLOPT_TIMEOUT => 20,
         ];
 
         $instance = $params['instance'] ?? '';

--- a/lib/Payrexx/Payrexx.php
+++ b/lib/Payrexx/Payrexx.php
@@ -19,7 +19,7 @@ use Payrexx\Models\Base;
  */
 class Payrexx
 {
-    public const CLIENT_VERSION = '2.0.15';
+    public const CLIENT_VERSION = '2.0.16';
 
     protected Communicator $communicator;
 


### PR DESCRIPTION
Adds CURLOPT_CONNECTTIMEOUT (5s) and CURLOPT_TIMEOUT (20s) to the cURL adapter so a slow/unresponsive API fails as a normal cURL error instead of hanging until PHP's max_execution_time kills the process mid-request (fatal). Bumps CLIENT_VERSION to 2.0.16.

Verified: normal call OK (~0.5s), connect-timeout returns ~5s and read-timeout ~20s (both cURL errno 28), no hang.

Refs PP-20387. Part 1 of 2 — the WooCommerce plugin will bundle SDK 2.0.16 and add the "don't auto-retry on timeout" safeguard.